### PR TITLE
Added -a to copy to preserve ownership

### DIFF
--- a/java/s2i/assemble
+++ b/java/s2i/assemble
@@ -51,8 +51,9 @@ function get_output_dir() {
 function copy_dir() {
   local src=$1
   local dest=$2
-
-  cp -r ${src}/* ${dest}
+  
+  # Copy recursively and preserve ownership: -a
+  cp -a ${src}/* ${dest}
   check_error "copying ${src} to ${dest}" $?
 }
 


### PR DESCRIPTION
The copying of the hawt-app doesn't preserve ownership, in some cases the user might want to do this