### PR TITLE
Part of OSFUSE-221: Standardize on S2I for on prem/cloud builds

### DIFF
--- a/java/images/jboss/s2i/assemble
+++ b/java/images/jboss/s2i/assemble
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 # Global S2I variable setup
 source `dirname "$0"`/s2i-setup
 
@@ -133,6 +132,13 @@ if [ -f "${S2I_SOURCE_DIR}/pom.xml" ]; then
   # If a pom.xml is present use maven
   setup_maven
   build_maven ${build_dir} ${DEPLOYMENTS_DIR}
+elif [ -f "${S2I_SOURCE_DIR}/Dockerfile" ] && [ -d "${S2I_SOURCE_DIR}/maven" ]; then
+  # This is a bindary build.
+  echo "S2I binary build detected"
+  binary_dir="${S2I_SOURCE_DIR}/maven"
+  echo "Copying binaries from ${binary_dir} to ${S2I_ARTIFACTS_DIR} ..."
+  copy_dir ${binary_dir} ${DEPLOYMENTS_DIR}
+  check_error "copying ${binary_dir} to ${DEPLOYMENTS_DIR}" $?  
 else
   binary_dir="${ARTIFACT_DIR:-${S2I_SOURCE_DIR}/deployments}"
   # Assuming that the source already contains compiled artefacts

--- a/java/images/rhel/s2i/assemble
+++ b/java/images/rhel/s2i/assemble
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 # Global S2I variable setup
 source `dirname "$0"`/s2i-setup
 
@@ -133,6 +132,13 @@ if [ -f "${S2I_SOURCE_DIR}/pom.xml" ]; then
   # If a pom.xml is present use maven
   setup_maven
   build_maven ${build_dir} ${DEPLOYMENTS_DIR}
+elif [ -f "${S2I_SOURCE_DIR}/Dockerfile" ] && [ -d "${S2I_SOURCE_DIR}/maven" ]; then
+  # This is a bindary build.
+  echo "S2I binary build detected"
+  binary_dir="${S2I_SOURCE_DIR}/maven"
+  echo "Copying binaries from ${binary_dir} to ${S2I_ARTIFACTS_DIR} ..."
+  copy_dir ${binary_dir} ${DEPLOYMENTS_DIR}
+  check_error "copying ${binary_dir} to ${DEPLOYMENTS_DIR}" $?  
 else
   binary_dir="${ARTIFACT_DIR:-${S2I_SOURCE_DIR}/deployments}"
   # Assuming that the source already contains compiled artefacts

--- a/java/templates/s2i/assemble
+++ b/java/templates/s2i/assemble
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 # Global S2I variable setup
 source `dirname "$0"`/s2i-setup
 
@@ -133,6 +132,13 @@ if [ -f "${S2I_SOURCE_DIR}/pom.xml" ]; then
   # If a pom.xml is present use maven
   setup_maven
   build_maven ${build_dir} ${DEPLOYMENTS_DIR}
+elif [ -f "${S2I_SOURCE_DIR}/Dockerfile" ] && [ -d "${S2I_SOURCE_DIR}/maven" ]; then
+  # This is a bindary build.
+  echo "S2I binary build detected"
+  binary_dir="${S2I_SOURCE_DIR}/maven"
+  echo "Copying binaries from ${binary_dir} to ${S2I_ARTIFACTS_DIR} ..."
+  copy_dir ${binary_dir} ${DEPLOYMENTS_DIR}
+  check_error "copying ${binary_dir} to ${DEPLOYMENTS_DIR}" $?  
 else
   binary_dir="${ARTIFACT_DIR:-${S2I_SOURCE_DIR}/deployments}"
   # Assuming that the source already contains compiled artefacts


### PR DESCRIPTION
This change detects a S2I binary builds and installs the binaries to the correct location on the image.  (Works for spring boot apps at least).