### PR TITLE
Revert changes for Maven installations via SCL

### DIFF
--- a/java/images/jboss/Dockerfile
+++ b/java/images/jboss/Dockerfile
@@ -1,6 +1,7 @@
 FROM jboss/base-jdk:8
 
-ENV JOLOKIA_VERSION="1.3.5" \
+ENV MAVEN_VERSION="3.3.3" \
+    JOLOKIA_VERSION="1.3.5" \
     PATH=$PATH:"/usr/local/s2i" \
     AB_JOLOKIA_PASSWORD_RANDOM="true" \
     AB_JOLOKIA_AUTH_OPENSHIFT="true" \
@@ -25,9 +26,12 @@ RUN echo securerandom.source=file:/dev/urandom >> /usr/lib/jvm/java/jre/lib/secu
 # Add jboss user to the root group
 RUN usermod -g root -G jboss jboss
 
-# Install Maven via SCL
 
-RUN yum install -y centos-release-scl && yum install -y rh-maven33-maven
+# Download Maven from Apache
+RUN curl https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
+    tar -xzf - -C /opt \
+ && ln -s /opt/apache-maven-${MAVEN_VERSION} /opt/maven \
+ && ln -s /opt/maven/bin/mvn /usr/bin/mvn
 
 
 # Jolokia agent

--- a/java/images/jboss/container-limits
+++ b/java/images/jboss/container-limits
@@ -49,14 +49,12 @@ max_memory() {
   fi
 }
 
-limit="$(core_limit)"
+local limit="$(core_limit)"
 if [ x$limit != x ]; then
-   export CONTAINER_CORE_LIMIT="${limit}"
+   export CONTAINER_CORE_LIMIT="$limit"
 fi
-unset limit
 
-limit="$(max_memory)"
-if [ x$limit != x ]; then
-  export CONTAINER_MAX_MEMORY="$limit"
+local max_mem="$(max_memory)"
+if [ x$max_mem != x ]; then
+  export CONTAINER_MAX_MEMORY="$max_mem"
 fi
-unset limit

--- a/java/images/jboss/java-default-options
+++ b/java/images/jboss/java-default-options
@@ -5,7 +5,7 @@
 #
 # Usage: JAVA_OPTIONS="$(java-default-options.sh)"
 
-# Env Vars evaluated:
+# Env Vars respected:
 
 # JAVA_OPTIONS: Checked for already set options
 # JAVA_MAX_MEM_RATIO: Ratio use to calculate a default maximum Memory, in percent.
@@ -70,5 +70,5 @@ cpu_core_tunning() {
   fi
 }
 
-# Echo options, trimming trailing and multiple spaces
+## Echo options, trimming trailing and multiple spaces
 echo "$(max_memory) $(diagnostics) $(cpu_core_tunning)" | awk '$1=$1'

--- a/java/images/rhel/Dockerfile
+++ b/java/images/rhel/Dockerfile
@@ -28,7 +28,7 @@ RUN usermod -g root -G jboss jboss
 # Install Maven via SCL
 
 COPY jboss.repo /etc/yum.repos.d/jboss.repo
-RUN yum install -y --skip-broken --enablerepo=jboss-rhel-rhscl rh-maven33-maven \
+RUN yum install -y --enablerepo=jboss-rhel-rhscl rh-maven33-maven \
     && yum clean all \
     && rm /etc/yum.repos.d/jboss.repo
 

--- a/java/images/rhel/Dockerfile
+++ b/java/images/rhel/Dockerfile
@@ -1,6 +1,7 @@
 FROM jboss-base-7/jdk8:1.2-28
 
-ENV JOLOKIA_VERSION="1.3.5" \
+ENV MAVEN_VERSION="3.3.3-1.el7" \
+    JOLOKIA_VERSION="1.3.5" \
     PATH=$PATH:"/usr/local/s2i" \
     AB_JOLOKIA_PASSWORD_RANDOM="true" \
     AB_JOLOKIA_AUTH_OPENSHIFT="true" \
@@ -25,9 +26,11 @@ RUN echo securerandom.source=file:/dev/urandom >> /usr/lib/jvm/java/jre/lib/secu
 # Add jboss user to the root group
 RUN usermod -g root -G jboss jboss
 
-# Install Maven via SCL
 
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && yum install -y rh-maven33-maven
+# Install Maven via RPM
+ADD "http://download.eng.bos.redhat.com/brewroot/packages/maven3/3.3.3/1.el7/noarch/maven3-${MAVEN_VERSION}.noarch.rpm" /tmp/
+RUN rpm -i "/tmp/maven3-${MAVEN_VERSION}.noarch.rpm" \
+ && rm "/tmp/maven3-${MAVEN_VERSION}.noarch.rpm"
 
 
 # Jolokia agent

--- a/java/images/rhel/Dockerfile
+++ b/java/images/rhel/Dockerfile
@@ -27,10 +27,7 @@ RUN usermod -g root -G jboss jboss
 
 # Install Maven via SCL
 
-COPY jboss.repo /etc/yum.repos.d/jboss.repo
-RUN yum install -y --enablerepo=jboss-rhel-rhscl rh-maven33-maven \
-    && yum clean all \
-    && rm /etc/yum.repos.d/jboss.repo
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && yum install -y rh-maven33-maven
 
 
 # Jolokia agent

--- a/java/images/rhel/container-limits
+++ b/java/images/rhel/container-limits
@@ -49,14 +49,12 @@ max_memory() {
   fi
 }
 
-limit="$(core_limit)"
+local limit="$(core_limit)"
 if [ x$limit != x ]; then
-   export CONTAINER_CORE_LIMIT="${limit}"
+   export CONTAINER_CORE_LIMIT="$limit"
 fi
-unset limit
 
-limit="$(max_memory)"
-if [ x$limit != x ]; then
-  export CONTAINER_MAX_MEMORY="$limit"
+local max_mem="$(max_memory)"
+if [ x$max_mem != x ]; then
+  export CONTAINER_MAX_MEMORY="$max_mem"
 fi
-unset limit

--- a/java/images/rhel/java-default-options
+++ b/java/images/rhel/java-default-options
@@ -5,7 +5,7 @@
 #
 # Usage: JAVA_OPTIONS="$(java-default-options.sh)"
 
-# Env Vars evaluated:
+# Env Vars respected:
 
 # JAVA_OPTIONS: Checked for already set options
 # JAVA_MAX_MEM_RATIO: Ratio use to calculate a default maximum Memory, in percent.
@@ -70,5 +70,5 @@ cpu_core_tunning() {
   fi
 }
 
-# Echo options, trimming trailing and multiple spaces
+## Echo options, trimming trailing and multiple spaces
 echo "$(max_memory) $(diagnostics) $(cpu_core_tunning)" | awk '$1=$1'

--- a/java/images/rhel/jboss.repo
+++ b/java/images/rhel/jboss.repo
@@ -1,6 +1,0 @@
-[jboss-rhel-rhscl]
-name=Red Hat RHEL7 SCL repo
-baseurl=http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/rhscl/1/os/
-enabled=1
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/java/templates/Dockerfile
+++ b/java/templates/Dockerfile
@@ -30,10 +30,7 @@ RUN usermod -g root -G jboss jboss
 
 # Install Maven via SCL
 {{? fp.param.base === "rhel"}}
-COPY jboss.repo /etc/yum.repos.d/jboss.repo
-RUN yum install -y --enablerepo=jboss-rhel-rhscl rh-maven33-maven \
-    && yum clean all \
-    && rm /etc/yum.repos.d/jboss.repo
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && yum install -y rh-maven33-maven
 {{??}}
 RUN yum install -y centos-release-scl && yum install -y rh-maven33-maven
 {{?}}

--- a/java/templates/Dockerfile
+++ b/java/templates/Dockerfile
@@ -3,7 +3,8 @@
     (fp.param.base === "rhel" ? "https://repository.jboss.org/nexus/content/repositories/fs-releases" : null);
 }}FROM {{= fp.config.base.from }}
 
-ENV JOLOKIA_VERSION="{{= fp.config.base.lib.version.jolokia }}" \
+ENV MAVEN_VERSION="{{= fp.config.base.lib.version.maven }}" \
+    JOLOKIA_VERSION="{{= fp.config.base.lib.version.jolokia }}" \
     PATH=$PATH:"/usr/local/s2i" \
     AB_JOLOKIA_PASSWORD_RANDOM="true" \
     AB_JOLOKIA_AUTH_OPENSHIFT="true" \
@@ -28,11 +29,17 @@ RUN echo securerandom.source=file:/dev/urandom >> /usr/lib/jvm/java/jre/lib/secu
 # Add jboss user to the root group
 RUN usermod -g root -G jboss jboss
 
-# Install Maven via SCL
-{{? fp.param.base === "rhel"}}
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && yum install -y rh-maven33-maven
+{{? fp.param.base === "rhel" }}
+# Install Maven via RPM
+ADD "http://download.eng.bos.redhat.com/brewroot/packages/maven3/{{= fp.config.base.lib.version.maven.split("-")[0] }}/1.el7/noarch/maven3-${MAVEN_VERSION}.noarch.rpm" /tmp/
+RUN rpm -i "/tmp/maven3-${MAVEN_VERSION}.noarch.rpm" \
+ && rm "/tmp/maven3-${MAVEN_VERSION}.noarch.rpm"
 {{??}}
-RUN yum install -y centos-release-scl && yum install -y rh-maven33-maven
+# Download Maven from Apache
+RUN curl https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
+    tar -xzf - -C /opt \
+ && ln -s /opt/apache-maven-${MAVEN_VERSION} /opt/maven \
+ && ln -s /opt/maven/bin/mvn /usr/bin/mvn
 {{?}}
 
 {{=

--- a/java/templates/Dockerfile
+++ b/java/templates/Dockerfile
@@ -31,7 +31,7 @@ RUN usermod -g root -G jboss jboss
 # Install Maven via SCL
 {{? fp.param.base === "rhel"}}
 COPY jboss.repo /etc/yum.repos.d/jboss.repo
-RUN yum install -y --skip-broken --enablerepo=jboss-rhel-rhscl rh-maven33-maven \
+RUN yum install -y --enablerepo=jboss-rhel-rhscl rh-maven33-maven \
     && yum clean all \
     && rm /etc/yum.repos.d/jboss.repo
 {{??}}

--- a/karaf/images/jboss/Dockerfile
+++ b/karaf/images/jboss/Dockerfile
@@ -2,7 +2,8 @@ FROM jboss/base-jdk:8
 
 MAINTAINER Dhiraj Bokde <dhirajsb@gmail.com>
 
-ENV JOLOKIA_VERSION="1.3.5" \
+ENV MAVEN_VERSION="3.3.3" \
+    JOLOKIA_VERSION="1.3.5" \
     PATH="/usr/local/s2i:$PATH" \
     AB_JOLOKIA_PASSWORD_RANDOM="true" \
     AB_JOLOKIA_AUTH_OPENSHIFT="true"
@@ -29,9 +30,11 @@ RUN echo securerandom.source=file:/dev/urandom >> /usr/lib/jvm/java/jre/lib/secu
 RUN usermod -g root -G jboss jboss
 
 
-# Install Maven via SCL
-
-RUN yum install -y centos-release-scl && yum install -y rh-maven33-maven
+# Download Maven from Apache
+RUN curl https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
+    tar -xzf - -C /opt \
+ && ln -s /opt/apache-maven-${MAVEN_VERSION} /opt/maven \
+ && ln -s /opt/maven/bin/mvn /usr/bin/mvn
 
 
 # Jolokia agent

--- a/karaf/images/jboss/Dockerfile
+++ b/karaf/images/jboss/Dockerfile
@@ -57,8 +57,8 @@ ADD README.md /usr/local/s2i/usage.txt
 
 # Copy deploy-and-run.sh for standalone images
 # Necessary to permit running with a randomised UID
-COPY deploy-and-run.sh container-limits java-default-options /deployments/
-RUN chmod a+x /deployments/deploy-and-run.sh /deployments/container-limits /deployments/java-default-options \
+COPY deploy-and-run.sh container-limits debug-options java-default-options /deployments/
+RUN chmod a+x /deployments/deploy-and-run.sh /deployments/container-limits /deployments/debug-options /deployments/java-default-options \
  && chmod a+x /usr/local/s2i/* \
  && chmod -R "g+rwX" /deployments \
  && chown -R jboss:root /deployments

--- a/karaf/images/jboss/s2i/run
+++ b/karaf/images/jboss/s2i/run
@@ -13,6 +13,15 @@ if [ -f "${DEPLOYMENTS_DIR}/java-default-options" ]; then
   source "${DEPLOYMENTS_DIR}/java-default-options"
 fi
 
+# set debug option
+if [ -f "${DEPLOYMENTS_DIR}/debug-options" ]; then
+  debug_opts=$($DEPLOYMENTS_DIR/debug-options)
+  if [ "x${debug_opts}" != x ]; then
+    export JAVA_DEBUG_OPTS=$($DEPLOYMENTS_DIR/debug-options)
+    export KARAF_DEBUG="true"
+  fi
+fi
+
 # Output from assemble script
 echo "Executing ${DEPLOYMENTS_DIR}/karaf/bin/karaf server ..."
 export DEPLOYMENTS_DIR

--- a/karaf/images/rhel/Dockerfile
+++ b/karaf/images/rhel/Dockerfile
@@ -32,7 +32,7 @@ RUN usermod -g root -G jboss jboss
 # Install Maven via SCL
 
 COPY jboss.repo /etc/yum.repos.d/jboss.repo
-RUN yum install -y --skip-broken --enablerepo=jboss-rhel-rhscl rh-maven33-maven \
+RUN yum install -y --enablerepo=jboss-rhel-rhscl rh-maven33-maven \
     && yum clean all \
     && rm /etc/yum.repos.d/jboss.repo
 

--- a/karaf/images/rhel/Dockerfile
+++ b/karaf/images/rhel/Dockerfile
@@ -31,10 +31,7 @@ RUN usermod -g root -G jboss jboss
 
 # Install Maven via SCL
 
-COPY jboss.repo /etc/yum.repos.d/jboss.repo
-RUN yum install -y --enablerepo=jboss-rhel-rhscl rh-maven33-maven \
-    && yum clean all \
-    && rm /etc/yum.repos.d/jboss.repo
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && yum install -y rh-maven33-maven
 
 
 # Jolokia agent

--- a/karaf/images/rhel/Dockerfile
+++ b/karaf/images/rhel/Dockerfile
@@ -2,7 +2,8 @@ FROM jboss-base-7/jdk8:1.2-28
 
 MAINTAINER Dhiraj Bokde <dhirajsb@gmail.com>
 
-ENV JOLOKIA_VERSION="1.3.5" \
+ENV MAVEN_VERSION="3.3.3-1.el7" \
+    JOLOKIA_VERSION="1.3.5" \
     PATH="/usr/local/s2i:$PATH" \
     AB_JOLOKIA_PASSWORD_RANDOM="true" \
     AB_JOLOKIA_AUTH_OPENSHIFT="true"
@@ -29,9 +30,10 @@ RUN echo securerandom.source=file:/dev/urandom >> /usr/lib/jvm/java/jre/lib/secu
 RUN usermod -g root -G jboss jboss
 
 
-# Install Maven via SCL
-
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && yum install -y rh-maven33-maven
+# Install Maven via RPM
+ADD "http://download.eng.bos.redhat.com/brewroot/packages/maven3/3.3.3/1.el7/noarch/maven3-${MAVEN_VERSION}.noarch.rpm" /tmp/
+RUN rpm -i "/tmp/maven3-${MAVEN_VERSION}.noarch.rpm" \
+ && rm "/tmp/maven3-${MAVEN_VERSION}.noarch.rpm"
 
 
 # Jolokia agent

--- a/karaf/images/rhel/jboss.repo
+++ b/karaf/images/rhel/jboss.repo
@@ -1,6 +1,0 @@
-[jboss-rhel-rhscl]
-name=Red Hat RHEL7 SCL repo
-baseurl=http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/rhscl/1/os/
-enabled=1
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/karaf/images/rhel/s2i/run
+++ b/karaf/images/rhel/s2i/run
@@ -13,6 +13,15 @@ if [ -f "${DEPLOYMENTS_DIR}/java-default-options" ]; then
   source "${DEPLOYMENTS_DIR}/java-default-options"
 fi
 
+# set debug option
+if [ -f "${DEPLOYMENTS_DIR}/debug-options" ]; then
+  debug_opts=$($DEPLOYMENTS_DIR/debug-options)
+  if [ "x${debug_opts}" != x ]; then
+    export JAVA_DEBUG_OPTS=$($DEPLOYMENTS_DIR/debug-options)
+    export KARAF_DEBUG="true"
+  fi
+fi
+
 # Output from assemble script
 echo "Executing ${DEPLOYMENTS_DIR}/karaf/bin/karaf server ..."
 export DEPLOYMENTS_DIR

--- a/karaf/templates/Dockerfile
+++ b/karaf/templates/Dockerfile
@@ -5,7 +5,8 @@
 
 MAINTAINER Dhiraj Bokde <dhirajsb@gmail.com>
 
-ENV JOLOKIA_VERSION="{{= fp.config.base.lib.version.jolokia }}" \
+ENV MAVEN_VERSION="{{= fp.config.base.lib.version.maven }}" \
+    JOLOKIA_VERSION="{{= fp.config.base.lib.version.jolokia }}" \
     PATH="/usr/local/s2i:$PATH" \
     AB_JOLOKIA_PASSWORD_RANDOM="true" \
     AB_JOLOKIA_AUTH_OPENSHIFT="true"
@@ -31,12 +32,17 @@ RUN echo securerandom.source=file:/dev/urandom >> /usr/lib/jvm/java/jre/lib/secu
 # Add jboss user to the root group
 RUN usermod -g root -G jboss jboss
 
-
-# Install Maven via SCL
-{{? fp.param.base === "rhel"}}
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && yum install -y rh-maven33-maven
+{{? fp.param.base === "rhel" }}
+# Install Maven via RPM
+ADD "http://download.eng.bos.redhat.com/brewroot/packages/maven3/{{= fp.config.base.lib.version.maven.split("-")[0] }}/1.el7/noarch/maven3-${MAVEN_VERSION}.noarch.rpm" /tmp/
+RUN rpm -i "/tmp/maven3-${MAVEN_VERSION}.noarch.rpm" \
+ && rm "/tmp/maven3-${MAVEN_VERSION}.noarch.rpm"
 {{??}}
-RUN yum install -y centos-release-scl && yum install -y rh-maven33-maven
+# Download Maven from Apache
+RUN curl https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
+    tar -xzf - -C /opt \
+ && ln -s /opt/apache-maven-${MAVEN_VERSION} /opt/maven \
+ && ln -s /opt/maven/bin/mvn /usr/bin/mvn
 {{?}}
 
 {{=

--- a/karaf/templates/Dockerfile
+++ b/karaf/templates/Dockerfile
@@ -34,10 +34,7 @@ RUN usermod -g root -G jboss jboss
 
 # Install Maven via SCL
 {{? fp.param.base === "rhel"}}
-COPY jboss.repo /etc/yum.repos.d/jboss.repo
-RUN yum install -y --enablerepo=jboss-rhel-rhscl rh-maven33-maven \
-    && yum clean all \
-    && rm /etc/yum.repos.d/jboss.repo
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && yum install -y rh-maven33-maven
 {{??}}
 RUN yum install -y centos-release-scl && yum install -y rh-maven33-maven
 {{?}}

--- a/karaf/templates/Dockerfile
+++ b/karaf/templates/Dockerfile
@@ -35,7 +35,7 @@ RUN usermod -g root -G jboss jboss
 # Install Maven via SCL
 {{? fp.param.base === "rhel"}}
 COPY jboss.repo /etc/yum.repos.d/jboss.repo
-RUN yum install -y --skip-broken --enablerepo=jboss-rhel-rhscl rh-maven33-maven \
+RUN yum install -y --enablerepo=jboss-rhel-rhscl rh-maven33-maven \
     && yum clean all \
     && rm /etc/yum.repos.d/jboss.repo
 {{??}}


### PR DESCRIPTION
There are sever issues with the latest changes as Maven is not on the path and hence cannot be found. Seems that the PRs slipped in untested.

I reverts the changes on branch master. The original changes are still available on branch `fis-2.0` and work for adapting the Maven installation can continue on this branch.