### PR TITLE
OSFUSE-548 - Include rsync in the image

### DIFF
--- a/java/images/jboss/Dockerfile
+++ b/java/images/jboss/Dockerfile
@@ -45,6 +45,8 @@ RUN chmod 444 /opt/jolokia/jolokia.jar \
 
 EXPOSE 8778
 
+# Install rsync
+RUN yum install -y rsync
 
 # S2I scripts + README
 COPY s2i /usr/local/s2i

--- a/java/templates/Dockerfile
+++ b/java/templates/Dockerfile
@@ -50,6 +50,11 @@ RUN curl https://archive.apache.org/dist/maven/maven-3/{{= mavenVersion }}/binar
             userGroupMode: "root",
             version: fp.config.base.lib.version.jolokia }) }}
 
+# Install rsync
+{{? fp.param.base != "rhel"}}
+RUN yum install -y rsync
+{{?}}
+
 # S2I scripts + README
 COPY s2i /usr/local/s2i
 RUN chmod 755 /usr/local/s2i/*


### PR DESCRIPTION
it is mandatory to support hot deploy. otherwise, 'oc rsync' defaults to
tar mode which has several restrictions.

I wasn't able to test it completely because I can't install a CDK on my Windows machine currently.