### PR TITLE
Enable Maven batch mode by default

### DIFF
--- a/java/images/jboss/s2i/assemble
+++ b/java/images/jboss/s2i/assemble
@@ -119,7 +119,7 @@ function build_maven() {
   local app_dir=$2
 
   # Default args: no tests, if a module is specified, only build this module
-  local maven_args=${MAVEN_ARGS:-package -DskipTests -e -Dfabric8.skip=true}
+  local maven_args=${MAVEN_ARGS:-package -DskipTests -e -Dfabric8.skip=true -B}
 
   echo "Found pom.xml ... "
   echo "Running 'mvn ${maven_env_args} ${maven_args} ${MAVEN_ARGS_APPEND}'"

--- a/java/images/rhel/s2i/assemble
+++ b/java/images/rhel/s2i/assemble
@@ -119,7 +119,7 @@ function build_maven() {
   local app_dir=$2
 
   # Default args: no tests, if a module is specified, only build this module
-  local maven_args=${MAVEN_ARGS:-package -DskipTests -e -Dfabric8.skip=true}
+  local maven_args=${MAVEN_ARGS:-package -DskipTests -e -Dfabric8.skip=true -B}
 
   echo "Found pom.xml ... "
   echo "Running 'mvn ${maven_env_args} ${maven_args} ${MAVEN_ARGS_APPEND}'"

--- a/java/templates/s2i/assemble
+++ b/java/templates/s2i/assemble
@@ -119,7 +119,7 @@ function build_maven() {
   local app_dir=$2
 
   # Default args: no tests, if a module is specified, only build this module
-  local maven_args=${MAVEN_ARGS:-package -DskipTests -e -Dfabric8.skip=true}
+  local maven_args=${MAVEN_ARGS:-package -DskipTests -e -Dfabric8.skip=true -B}
 
   echo "Found pom.xml ... "
   echo "Running 'mvn ${maven_env_args} ${maven_args} ${MAVEN_ARGS_APPEND}'"

--- a/karaf/images/jboss/s2i/assemble
+++ b/karaf/images/jboss/s2i/assemble
@@ -6,7 +6,7 @@ source `dirname "$0"`/s2i-setup
 # Maven arguments setting up the environment
 maven_env_args="-Dmaven.repo.local=${S2I_ARTIFACTS_DIR}/m2"
 
-DEFAULT_KARAF_MAVEN_ARGS="install -DskipTests -e -Dfabric8.skip=true"
+DEFAULT_KARAF_MAVEN_ARGS="install -DskipTests -e -Dfabric8.skip=true -B"
 
 # Helper functions:
 function check_error() {

--- a/karaf/images/rhel/s2i/assemble
+++ b/karaf/images/rhel/s2i/assemble
@@ -6,7 +6,7 @@ source `dirname "$0"`/s2i-setup
 # Maven arguments setting up the environment
 maven_env_args="-Dmaven.repo.local=${S2I_ARTIFACTS_DIR}/m2"
 
-DEFAULT_KARAF_MAVEN_ARGS="install -DskipTests -e -Dfabric8.skip=true"
+DEFAULT_KARAF_MAVEN_ARGS="install -DskipTests -e -Dfabric8.skip=true -B"
 
 # Helper functions:
 function check_error() {

--- a/karaf/templates/s2i/assemble
+++ b/karaf/templates/s2i/assemble
@@ -6,7 +6,7 @@ source `dirname "$0"`/s2i-setup
 # Maven arguments setting up the environment
 maven_env_args="-Dmaven.repo.local=${S2I_ARTIFACTS_DIR}/m2"
 
-DEFAULT_KARAF_MAVEN_ARGS="install -DskipTests -e -Dfabric8.skip=true"
+DEFAULT_KARAF_MAVEN_ARGS="install -DskipTests -e -Dfabric8.skip=true -B"
 
 # Helper functions:
 function check_error() {


### PR DESCRIPTION
This change enables the Maven batch mode by default and thus reduces the download percentage spam during builds:

![image](https://user-images.githubusercontent.com/202474/33431485-ca1e5088-d5d4-11e7-8514-411db745817a.png)
