### PR TITLE
More fairness on the type of fat jar

### DIFF
--- a/java/images/jboss/s2i/assemble
+++ b/java/images/jboss/s2i/assemble
@@ -193,8 +193,8 @@ else
   check_error "copying ${binary_dir} to ${DEPLOYMENTS_DIR}" $?
 fi
 
-# check if this is a SpringBoot executable archive, which can be exploded
-echo "Checking for SpringBoot archive..."
+# check if this is a fat jar executable archive. SpringBoot fat jars can be exploded
+echo "Checking for fat jar archive..."
 old_dir=`pwd`
 cd "${DEPLOYMENTS_DIR}"
 nr_jars=`ls *.jar 2>/dev/null | grep -v '^original-' | wc -l | tr -d '[[:space:]]'`

--- a/java/images/rhel/s2i/assemble
+++ b/java/images/rhel/s2i/assemble
@@ -193,8 +193,8 @@ else
   check_error "copying ${binary_dir} to ${DEPLOYMENTS_DIR}" $?
 fi
 
-# check if this is a SpringBoot executable archive, which can be exploded
-echo "Checking for SpringBoot archive..."
+# check if this is a fat jar executable archive. SpringBoot fat jars can be exploded
+echo "Checking for fat jar archive..."
 old_dir=`pwd`
 cd "${DEPLOYMENTS_DIR}"
 nr_jars=`ls *.jar 2>/dev/null | grep -v '^original-' | wc -l | tr -d '[[:space:]]'`

--- a/java/templates/s2i/assemble
+++ b/java/templates/s2i/assemble
@@ -193,8 +193,8 @@ else
   check_error "copying ${binary_dir} to ${DEPLOYMENTS_DIR}" $?
 fi
 
-# check if this is a SpringBoot executable archive, which can be exploded
-echo "Checking for SpringBoot archive..."
+# check if this is a fat jar executable archive. SpringBoot fat jars can be exploded
+echo "Checking for fat jar archive..."
 old_dir=`pwd`
 cd "${DEPLOYMENTS_DIR}"
 nr_jars=`ls *.jar 2>/dev/null | grep -v '^original-' | wc -l | tr -d '[[:space:]]'`


### PR DESCRIPTION
Now that builds are displayed on Openshift main dashboard, we should change this log, as it references spring-boot for any kind of application (e.g. vertx, as noticed by @cescoffier).