### PR TITLE
OSFUSE-648: Enable jstat to work properly on OpenShift

### DIFF
--- a/java/images/jboss/Dockerfile
+++ b/java/images/jboss/Dockerfile
@@ -85,7 +85,10 @@ RUN chmod 755 /opt/run-java/run-env.sh
 # Necessary to permit running with a randomised UID
 RUN mkdir -p /deployments/data \
  && chmod -R "g+rwX" /deployments \
- && chown -R jboss:root /deployments
+ && chown -R jboss:root /deployments \
+ && chmod -R "g+rwX" /home/jboss \
+ && chown -R jboss:root /home/jboss \
+ && chmod 664 /etc/passwd
 
 # S2I requires a numeric, non-0 UID. This is the UID for the jboss user in the base image
 

--- a/java/images/jboss/s2i/assemble
+++ b/java/images/jboss/s2i/assemble
@@ -216,4 +216,7 @@ if [ ${nr_jars} = 1 ]; then
 fi
 cd "${old_dir}"
 
+# Remove java temporary hsperfdata directory owned by the jboss user
+rm -rf /tmp/hsperfdata_jboss
+
 echo "... done"

--- a/java/images/jboss/s2i/run
+++ b/java/images/jboss/s2i/run
@@ -47,6 +47,11 @@ if [ -f "${DEPLOYMENTS_DIR}/META-INF/MANIFEST.MF" ]; then
 	export JAVA_MAIN_CLASS="${main_class}"
 fi
 
+# Update the jboss user UID entry in /etc/passwd
+sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > /tmp/passwd
+cat /tmp/passwd > /etc/passwd
+rm /tmp/passwd
+
 if [ -f "${DEPLOYMENTS_DIR}/bin/run.sh" ]; then
     echo "Starting the application using the bundled ${DEPLOYMENTS_DIR}/bin/run.sh ..."
     exec ${DEPLOYMENTS_DIR}/bin/run.sh $args ${JAVA_ARGS}

--- a/java/images/rhel/Dockerfile
+++ b/java/images/rhel/Dockerfile
@@ -82,7 +82,10 @@ RUN chmod 755 /opt/run-java/run-env.sh
 # Necessary to permit running with a randomised UID
 RUN mkdir -p /deployments/data \
  && chmod -R "g+rwX" /deployments \
- && chown -R jboss:root /deployments
+ && chown -R jboss:root /deployments \
+ && chmod -R "g+rwX" /home/jboss \
+ && chown -R jboss:root /home/jboss \
+ && chmod 664 /etc/passwd
 
 # S2I requires a numeric, non-0 UID. This is the UID for the jboss user in the base image
 

--- a/java/images/rhel/s2i/assemble
+++ b/java/images/rhel/s2i/assemble
@@ -216,4 +216,7 @@ if [ ${nr_jars} = 1 ]; then
 fi
 cd "${old_dir}"
 
+# Remove java temporary hsperfdata directory owned by the jboss user
+rm -rf /tmp/hsperfdata_jboss
+
 echo "... done"

--- a/java/images/rhel/s2i/run
+++ b/java/images/rhel/s2i/run
@@ -47,6 +47,11 @@ if [ -f "${DEPLOYMENTS_DIR}/META-INF/MANIFEST.MF" ]; then
 	export JAVA_MAIN_CLASS="${main_class}"
 fi
 
+# Update the jboss user UID entry in /etc/passwd
+sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > /tmp/passwd
+cat /tmp/passwd > /etc/passwd
+rm /tmp/passwd
+
 if [ -f "${DEPLOYMENTS_DIR}/bin/run.sh" ]; then
     echo "Starting the application using the bundled ${DEPLOYMENTS_DIR}/bin/run.sh ..."
     exec ${DEPLOYMENTS_DIR}/bin/run.sh $args ${JAVA_ARGS}

--- a/java/templates/Dockerfile
+++ b/java/templates/Dockerfile
@@ -77,7 +77,10 @@ RUN chmod 755 /opt/run-java/run-env.sh
 # Necessary to permit running with a randomised UID
 RUN mkdir -p /deployments/data \
  && chmod -R "g+rwX" /deployments \
- && chown -R jboss:root /deployments
+ && chown -R jboss:root /deployments \
+ && chmod -R "g+rwX" /home/jboss \
+ && chown -R jboss:root /home/jboss \
+ && chmod 664 /etc/passwd
 
 # S2I requires a numeric, non-0 UID. This is the UID for the jboss user in the base image
 {{? fp.param.base === "rhel"}}

--- a/java/templates/s2i/assemble
+++ b/java/templates/s2i/assemble
@@ -216,4 +216,7 @@ if [ ${nr_jars} = 1 ]; then
 fi
 cd "${old_dir}"
 
+# Remove java temporary hsperfdata directory owned by the jboss user
+rm -rf /tmp/hsperfdata_jboss
+
 echo "... done"

--- a/java/templates/s2i/run
+++ b/java/templates/s2i/run
@@ -47,6 +47,11 @@ if [ -f "${DEPLOYMENTS_DIR}/META-INF/MANIFEST.MF" ]; then
 	export JAVA_MAIN_CLASS="${main_class}"
 fi
 
+# Update the jboss user UID entry in /etc/passwd
+sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > /tmp/passwd
+cat /tmp/passwd > /etc/passwd
+rm /tmp/passwd
+
 if [ -f "${DEPLOYMENTS_DIR}/bin/run.sh" ]; then
     echo "Starting the application using the bundled ${DEPLOYMENTS_DIR}/bin/run.sh ..."
     exec ${DEPLOYMENTS_DIR}/bin/run.sh $args ${JAVA_ARGS}

--- a/karaf/images/jboss/Dockerfile
+++ b/karaf/images/jboss/Dockerfile
@@ -88,8 +88,10 @@ COPY deploy-and-run.sh container-limits debug-options java-default-options /depl
 RUN chmod a+x /deployments/deploy-and-run.sh /deployments/container-limits /deployments/debug-options /deployments/java-default-options \
  && chmod a+x /usr/local/s2i/* \
  && chmod -R "g+rwX" /deployments \
- && chown -R jboss:root /deployments
-
+ && chown -R jboss:root /deployments \
+ && chmod -R "g+rwX" /home/jboss \
+ && chown -R jboss:root /home/jboss \
+ && chmod 664 /etc/passwd
 
 # S2I requires a numeric, non-0 UID. This is the UID for the jboss user in the base image
 

--- a/karaf/images/jboss/s2i/assemble
+++ b/karaf/images/jboss/s2i/assemble
@@ -188,4 +188,7 @@ sed -i 's/^\(.*rootLogger.*\), *out *,/\1, stdout,/' ${DEPLOYMENTS_DIR}/karaf/et
 # allow overriding defaults in setenv
 sed -i 's/^\(JAVA_.*\)=\([^ ]*\)/\1=${\1:-\2}/' ${DEPLOYMENTS_DIR}/karaf/bin/setenv
 
+# Remove java temporary hsperfdata directory owned by the jboss user
+rm -rf /tmp/hsperfdata_jboss
+
 echo "...done!"

--- a/karaf/images/jboss/s2i/run
+++ b/karaf/images/jboss/s2i/run
@@ -47,6 +47,11 @@ if [ -z "${KARAF_OPTS}" ]; then
   export KARAF_OPTS
 fi
 
+# Update the jboss user UID entry in /etc/passwd
+sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > /tmp/passwd
+cat /tmp/passwd > /etc/passwd
+rm /tmp/passwd
+
 # force karaf to exec java process so docker runs a single process with PID 1
 export KARAF_EXEC=exec
 

--- a/karaf/images/rhel/Dockerfile
+++ b/karaf/images/rhel/Dockerfile
@@ -87,10 +87,10 @@ COPY deploy-and-run.sh container-limits debug-options java-default-options /depl
 RUN chmod a+x /deployments/deploy-and-run.sh /deployments/container-limits /deployments/debug-options /deployments/java-default-options \
  && chmod a+x /usr/local/s2i/* \
  && chmod -R "g+rwX" /deployments \
- && chown -R jboss:root /deployments
-
-RUN chmod -R "g+rwX" /home/jboss && chown -R jboss:root /home/jboss
-
+ && chown -R jboss:root /deployments \
+ && chmod -R "g+rwX" /home/jboss \
+ && chown -R jboss:root /home/jboss \
+ && chmod 664 /etc/passwd
 
 # S2I requires a numeric, non-0 UID. This is the UID for the jboss user in the base image
 

--- a/karaf/images/rhel/s2i/assemble
+++ b/karaf/images/rhel/s2i/assemble
@@ -188,4 +188,7 @@ sed -i 's/^\(.*rootLogger.*\), *out *,/\1, stdout,/' ${DEPLOYMENTS_DIR}/karaf/et
 # allow overriding defaults in setenv
 sed -i 's/^\(JAVA_.*\)=\([^ ]*\)/\1=${\1:-\2}/' ${DEPLOYMENTS_DIR}/karaf/bin/setenv
 
+# Remove java temporary hsperfdata directory owned by the jboss user
+rm -rf /tmp/hsperfdata_jboss
+
 echo "...done!"

--- a/karaf/images/rhel/s2i/run
+++ b/karaf/images/rhel/s2i/run
@@ -47,6 +47,11 @@ if [ -z "${KARAF_OPTS}" ]; then
   export KARAF_OPTS
 fi
 
+# Update the jboss user UID entry in /etc/passwd
+sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > /tmp/passwd
+cat /tmp/passwd > /etc/passwd
+rm /tmp/passwd
+
 # force karaf to exec java process so docker runs a single process with PID 1
 export KARAF_EXEC=exec
 

--- a/karaf/templates/Dockerfile
+++ b/karaf/templates/Dockerfile
@@ -82,10 +82,10 @@ COPY deploy-and-run.sh container-limits debug-options java-default-options /depl
 RUN chmod a+x /deployments/deploy-and-run.sh /deployments/container-limits /deployments/debug-options /deployments/java-default-options \
  && chmod a+x /usr/local/s2i/* \
  && chmod -R "g+rwX" /deployments \
- && chown -R jboss:root /deployments
-{{? fp.param.base === "rhel"}}
-RUN chmod -R "g+rwX" /home/jboss && chown -R jboss:root /home/jboss
-{{?}}
+ && chown -R jboss:root /deployments \
+ && chmod -R "g+rwX" /home/jboss \
+ && chown -R jboss:root /home/jboss \
+ && chmod 664 /etc/passwd
 
 # S2I requires a numeric, non-0 UID. This is the UID for the jboss user in the base image
 {{? fp.param.base === "rhel"}}

--- a/karaf/templates/s2i/assemble
+++ b/karaf/templates/s2i/assemble
@@ -188,4 +188,7 @@ sed -i 's/^\(.*rootLogger.*\), *out *,/\1, stdout,/' ${DEPLOYMENTS_DIR}/karaf/et
 # allow overriding defaults in setenv
 sed -i 's/^\(JAVA_.*\)=\([^ ]*\)/\1=${\1:-\2}/' ${DEPLOYMENTS_DIR}/karaf/bin/setenv
 
+# Remove java temporary hsperfdata directory owned by the jboss user
+rm -rf /tmp/hsperfdata_jboss
+
 echo "...done!"

--- a/karaf/templates/s2i/run
+++ b/karaf/templates/s2i/run
@@ -47,6 +47,11 @@ if [ -z "${KARAF_OPTS}" ]; then
   export KARAF_OPTS
 fi
 
+# Update the jboss user UID entry in /etc/passwd
+sed "/^jboss/s/[^:]*/$(id -u)/3" /etc/passwd > /tmp/passwd
+cat /tmp/passwd > /etc/passwd
+rm /tmp/passwd
+
 # force karaf to exec java process so docker runs a single process with PID 1
 export KARAF_EXEC=exec
 


### PR DESCRIPTION
Relates to: https://issues.jboss.org/browse/OSFUSE-648