### PR TITLE
Prefix hosts with a wildcard '*' in env var 'http.nonProxyHosts'

### DIFF
--- a/java/images/jboss/run-java.sh
+++ b/java/images/jboss/run-java.sh
@@ -462,7 +462,8 @@ proxy_options() {
 
   local noProxy="${no_proxy:-${NO_PROXY:-}}"
   if [ -n "$noProxy" ] ; then
-    ret="$ret -Dhttp.nonProxyHosts=\"$(echo $noProxy | sed -e 's/,[[:space:]]*/|/g')\""
+    # Replace separator "," by "|" and prefix hosts with a wildcard '*' (ex: '.svc' -> '*.svc') because OpenShift doesn't allow wildcards in  $no_proxy
+    ret="$ret -Dhttp.nonProxyHosts=\"$(echo $noProxy | sed -e 's/,[[:space:]]*/|/g' | sed -e 's/^\./*./g'  | sed -e 's/|\./|*./g')\""
   fi
   echo "$ret"
 }

--- a/java/images/rhel/run-java.sh
+++ b/java/images/rhel/run-java.sh
@@ -462,7 +462,8 @@ proxy_options() {
 
   local noProxy="${no_proxy:-${NO_PROXY:-}}"
   if [ -n "$noProxy" ] ; then
-    ret="$ret -Dhttp.nonProxyHosts=\"$(echo $noProxy | sed -e 's/,[[:space:]]*/|/g')\""
+    # Replace separator "," by "|" and prefix hosts with a wildcard '*' (ex: '.svc' -> '*.svc') because OpenShift doesn't allow wildcards in  $no_proxy
+    ret="$ret -Dhttp.nonProxyHosts=\"$(echo $noProxy | sed -e 's/,[[:space:]]*/|/g' | sed -e 's/^\./*./g'  | sed -e 's/|\./|*./g')\""
   fi
   echo "$ret"
 }


### PR DESCRIPTION
Property **http.nonProxyHosts** allows to use `*` for pattern matching. 
For example : `-Dhttp.nonProxyHosts=” *.foo.com|localhost”`

But Openshift doesn't  accept `*` attached to a domain suffix. That's why  `NO_PROXY` is set like this : 

```
NO_PROXY=.example.com,.local,127.0.0.1
```

This PR prefixes subdomains with a `*` using the two next commands :
- `sed -e 's/^\./*./g'`   : to replace the first subdomain if `$noProxy` is starting with a subdomain.
- `sed -e 's/|\./|*./g'` : to replace other subdomains.


References :

https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html
https://docs.openshift.com/container-platform/3.9/install_config/http_proxies.html#configuring-no-proxy