### PR TITLE
220 useproductized jolokia fuse 7.x.redhat

### DIFF
--- a/java/images.yml
+++ b/java/images.yml
@@ -25,11 +25,8 @@ config:
       user: "jboss"
       home: "/home/jboss"
       description: "RHEL S2I Java builder image with OpenJDK 8"
-      # Re-enable when productised version of jolokia is available
-      # mavenRepo: "https://maven.repository.redhat.com/ga"
+      mavenRepo: "https://maven.repository.redhat.com/ga"
       version:
         maven: "3.3.3-1.el7"
-        # Re-enable when productised version is available:
-        # jolokia: "1.5.0.redhat-1"
-        jolokia: 1.5.0
+        jolokia: "1.5.0.redhat-1"
         jmxexporter: "0.3.1"

--- a/karaf/images.yml
+++ b/karaf/images.yml
@@ -27,12 +27,9 @@ config:
       user: "jboss"
       home: "/home/jboss"
       description: "RHEL S2I Karaf builder image with OpenJDK 8"
-      # Re-enable when productised version of jolokia is available
-      # mavenRepo: "https://maven.repository.redhat.com/ga"
+      mavenRepo: "https://maven.repository.redhat.com/ga"
       version:
         maven: "3.3.3-1.el7"
-        # Re-enable when productised version is available:
-        # jolokia: "1.5.0.redhat-1"
-        jolokia: 1.5.0
+        jolokia: "1.5.0.redhat-1"
         karaf: "6.3.0.redhat-187"
         jmxexporter: "0.3.1"


### PR DESCRIPTION
should we change also at these places?

https://github.com/fabric8io-images/s2i/blob/41cf3eaea0366580261b86ba67f24a0f6831f6c6/java/images/rhel/Dockerfile#L15

https://github.com/fabric8io-images/s2i/blob/41cf3eaea0366580261b86ba67f24a0f6831f6c6/java/images/rhel/Dockerfile#L61
Why is it retrieving with curl? should we do it also with curl but with the maven redhat repository and productized version?