### PR TITLE
Fixes http.nonProxyHosts variable assignment

### DIFF
--- a/java/images/centos/run-java.sh
+++ b/java/images/centos/run-java.sh
@@ -483,7 +483,7 @@ proxy_options() {
 
   local noProxy="${no_proxy:-${NO_PROXY:-}}"
   if [ -n "$noProxy" ] ; then
-    ret="$ret -Dhttp.nonProxyHosts=\"$(echo "|$noProxy" | sed -e 's/,[[:space:]]*/|/g' | sed -e 's/|\./|\*\./g' | cut -c 2-)\""
+    ret="$ret -Dhttp.nonProxyHosts=$(echo "|$noProxy" | sed -e 's/,[[:space:]]*/|/g' | sed -e 's/|\./|\*\./g' | cut -c 2-)"
   fi
   echo "$ret"
 }


### PR DESCRIPTION
Fixes http.nonProxyHosts variable. Extra \" makes java handle incorrectly. Similar to #229